### PR TITLE
Refactor Excluder into abstract base class and create ROIExcluder child class

### DIFF
--- a/docs/compoundgenerator.rst
+++ b/docs/compoundgenerator.rst
@@ -59,10 +59,10 @@ generator as it is not repeated.
 The following is `not` legal::
 
     from scanpointgenerator import LineGenerator, CompoundGenerator, \
-    Excluder, CircularROI
+    ROIExcluder, CircularROI
 
     xs = LineGenerator("x", "mm", 0, 1, 2)
     ys = LineGenerator("y", "mm", 0, 1, 2)
     zs = LineGenerator("z", "mm", 0, 1, 2)
-    exc = Excluder(CircularROI([0, 0], 1), ["x", "z"])
+    exc = ROIExcluder([CircularROI([0, 0], 1)], ["x", "z"])
     gen = CompoundGenerator([zs, ys, xs], [exc], []) # xs and zs are not consecutive

--- a/docs/creating.rst
+++ b/docs/creating.rst
@@ -14,12 +14,12 @@ points in the y direction
     :include-source:
 
     from scanpointgenerator import LineGenerator, SpiralGenerator, \
-    CompoundGenerator, Excluder, RandomOffsetMutator, RectangularROI
+    CompoundGenerator, ROIExcluder, RandomOffsetMutator, RectangularROI
     from scanpointgenerator.plotgenerator import plot_generator
 
     spiral = SpiralGenerator(["x", "y"], "mm", [0.0, 0.0], 10.0,
                              alternate=True)
-    rectangle = Excluder(RectangularROI([1.0, 1.0], 8.0, 8.0), ["x", "y"])
+    rectangle = ROIExcluder([RectangularROI([1.0, 1.0], 8.0, 8.0)], ["x", "y"])
     mutator = RandomOffsetMutator(2, ["x", "y"], dict(x=0.0, y=0.25))
     gen = CompoundGenerator([spiral], [rectangle], [mutator])
 
@@ -65,12 +65,12 @@ Three nested line scans with an excluder operating on the two innermost axes
     :include-source:
 
     from scanpointgenerator import LineGenerator, CompoundGenerator, \
-    Excluder, CircularROI
+    ROIExcluder, CircularROI
 
     line1 = LineGenerator("x", "mm", 0.0, 2.0, 3)
     line2 = LineGenerator("y", "mm", 0.0, 1.0, 2)
     line3 = LineGenerator("z", "mm", 0.0, 1.0, 2)
-    circle = Excluder(CircularROI([1.0, 1.0], 1.0), ["x", "y"])
+    circle = ROIExcluder([CircularROI([1.0, 1.0], 1.0)], ["x", "y"])
     gen = CompoundGenerator([line3, line2, line1], [circle], [])
     gen.prepare()
 

--- a/docs/excluders.rst
+++ b/docs/excluders.rst
@@ -4,30 +4,37 @@ Excluders
 =========
 
 Excluders are used to filter points in a generator based on a pair of
-coordinates and a region of interest.
+coordinates and some attribute of the point, for example its position or
+duration.
+
+ROIExcluders
+============
+
+ROIExcluders filter points that fall outside of a given a region of interest.
 
 .. module:: scanpointgenerator
 
-.. autoclass:: Excluder
+.. autoclass:: ROIExcluder
     :members:
 
 CircularROI Example
 -------------------
 
-Here we use a CircularROI to filter the points of a snake scan
+Here we use CircularROIs to filter the points of a snake scan
 
 .. plot::
     :include-source:
 
     from scanpointgenerator import LineGenerator, CompoundGenerator, \
-    Excluder, CircularROI
+    ROIExcluder, CircularROI
     from scanpointgenerator.plotgenerator import plot_generator
 
     x = LineGenerator("x", "mm", 0.0, 4.0, 5, alternate=True)
     y = LineGenerator("y", "mm", 0.0, 3.0, 4)
-    circle = Excluder(CircularROI([2.0, 1.0], 2.0), ["x", "y"])
+    circles = ROIExcluder([CircularROI([1.0, 2.0], 2.0),
+                           CircularROI([2.0, 1.0], 2.0)], ["x", "y"])
     gen = CompoundGenerator([y, x], [], [])
-    plot_generator(gen, circle)
+    plot_generator(gen, circles)
 
 And with the excluder applied
 
@@ -35,12 +42,12 @@ And with the excluder applied
     :include-source:
 
     from scanpointgenerator import LineGenerator, CompoundGenerator, \
-    Excluder, CircularROI
+    ROIExcluder, CircularROI
     from scanpointgenerator.plotgenerator import plot_generator
 
     x = LineGenerator("x", "mm", 0.0, 4.0, 5, alternate=True)
     y = LineGenerator("y", "mm", 0.0, 3.0, 4)
-    circle = Excluder(CircularROI([2.0, 1.0], 2.0), ["x", "y"])
-    excluder = Excluder(circle, ['x', 'y'])
-    gen = CompoundGenerator([y, x], [circle], [])
+    circles = ROIExcluder([CircularROI([1.0, 2.0], 2.0),
+                           CircularROI([2.0, 1.0], 2.0)], ["x", "y"])
+    gen = CompoundGenerator([y, x], [circles], [])
     plot_generator(gen, circle)

--- a/docs/excluders.rst
+++ b/docs/excluders.rst
@@ -50,4 +50,4 @@ And with the excluder applied
     circles = ROIExcluder([CircularROI([1.0, 2.0], 2.0),
                            CircularROI([2.0, 1.0], 2.0)], ["x", "y"])
     gen = CompoundGenerator([y, x], [circles], [])
-    plot_generator(gen, circle)
+    plot_generator(gen, circles)

--- a/scanpointgenerator/__init__.py
+++ b/scanpointgenerator/__init__.py
@@ -1,4 +1,5 @@
 from scanpointgenerator.core import *
 from scanpointgenerator.generators import *
+from scanpointgenerator.excluders import *
 from scanpointgenerator.rois import *
 from scanpointgenerator.mutators import *

--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -78,10 +78,10 @@ class CompoundGenerator(object):
         # this changes the alternating case a little (without doing this, we
         # may have started in reverse direction)
         for excluder_ in [e for e in excluders if isinstance(e, ROIExcluder)]:
-            rect_rois = [r for r in excluder_.rois
-                         if isinstance(r, RectangularROI) and r.angle == 0]
-            if len(rect_rois) == 1:
-                rect = rect_rois[0]
+            if len(excluder_.rois) == 1 \
+                    and isinstance(excluder_.rois[0], RectangularROI) \
+                    and excluder_.rois[0].angle == 0:
+                rect = excluder_.rois[0]
                 axis_1, axis_2 = excluder_.axes[0], excluder_.axes[1]
                 gen_1 = [g for g in generators if axis_1 in g.axes][0]
                 gen_2 = [g for g in generators if axis_2 in g.axes][0]
@@ -113,11 +113,8 @@ class CompoundGenerator(object):
                         len(points_2), gen_2.alternate)
                     generators[generators.index(gen_1)] = new_gen1
                     generators[generators.index(gen_2)] = new_gen2
-                    # Remove ROI from Excluder
-                    excluder_.rois.remove(rect)
-                    if not excluder_.rois:
-                        # Remove Excluder if it is now empty
-                        excluders.remove(excluder_)
+                    # Remove Excluder as it is now empty
+                    excluders.remove(excluder_)
 
         for generator in generators:
             generator.prepare_positions()

--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -76,36 +76,45 @@ class CompoundGenerator(object):
         # we should restrict the resulting grid rather than merge dimensions
         # this changes the alternating case a little (without doing this, we
         # may have started in reverse direction)
-        for rect in [r for r in excluders \
-                if isinstance(r.roi, RectangularROI) and r.roi.angle == 0]:
-            axis_1, axis_2 = rect.scannables[0], rect.scannables[1]
-            gen_1 = [g for g in generators if axis_1 in g.axes][0]
-            gen_2 = [g for g in generators if axis_2 in g.axes][0]
-            if gen_1 is gen_2:
-                continue
-            if isinstance(gen_1, LineGenerator) \
-                    and isinstance(gen_2, LineGenerator):
-                gen_1.prepare_positions()
-                gen_2.prepare_positions()
-                valid = np.full(gen_1.size, True, dtype=np.int8)
-                valid &= gen_1.positions[axis_1] \
-                        <= rect.roi.width + rect.roi.start[0]
-                valid &= gen_1.positions[axis_1] >= rect.roi.start[0]
-                points_1 = gen_1.positions[axis_1][valid.astype(np.bool)]
-                valid = np.full(gen_2.size, True, dtype=np.int8)
-                valid &= gen_2.positions[axis_2] \
-                        <= rect.roi.height + rect.roi.start[1]
-                valid &= gen_2.positions[axis_2] >= rect.roi.start[1]
-                points_2 = gen_2.positions[axis_2][valid.astype(np.bool)]
-                new_gen1 = LineGenerator(
-                    gen_1.axes, gen_1.units, points_1[0], points_1[-1],
-                    len(points_1), gen_1.alternate)
-                new_gen2 = LineGenerator(
-                    gen_2.axes, gen_2.units, points_2[0], points_2[-1],
-                    len(points_2), gen_2.alternate)
-                generators[generators.index(gen_1)] = new_gen1
-                generators[generators.index(gen_2)] = new_gen2
-                excluders.remove(rect)
+        for excluder_ in excluders:
+            for roi_ in [r for r in excluder_.rois
+                         if isinstance(r, RectangularROI) and r.angle == 0]:
+                axis_1, axis_2 = excluder_.axes[0], excluder_.axes[1]
+                gen_1 = [g for g in generators if axis_1 in g.axes][0]
+                gen_2 = [g for g in generators if axis_2 in g.axes][0]
+                if gen_1 is gen_2:
+                    continue
+                if isinstance(gen_1, LineGenerator) \
+                        and isinstance(gen_2, LineGenerator):
+                    gen_1.prepare_positions()
+                    gen_2.prepare_positions()
+                    # Filter by axis 1
+                    valid = np.full(gen_1.size, True, dtype=np.int8)
+                    valid &= \
+                        gen_1.positions[axis_1] <= roi_.width + roi_.start[0]
+                    valid &= \
+                        gen_1.positions[axis_1] >= roi_.start[0]
+                    points_1 = gen_1.positions[axis_1][valid.astype(np.bool)]
+                    # Filter by axis 2
+                    valid = np.full(gen_2.size, True, dtype=np.int8)
+                    valid &= \
+                        gen_2.positions[axis_2] <= roi_.height + roi_.start[1]
+                    valid &= gen_2.positions[axis_2] >= roi_.start[1]
+                    points_2 = gen_2.positions[axis_2][valid.astype(np.bool)]
+                    # Recreate generators to replace larger generators + ROI
+                    new_gen1 = LineGenerator(
+                        gen_1.axes, gen_1.units, points_1[0], points_1[-1],
+                        len(points_1), gen_1.alternate)
+                    new_gen2 = LineGenerator(
+                        gen_2.axes, gen_2.units, points_2[0], points_2[-1],
+                        len(points_2), gen_2.alternate)
+                    generators[generators.index(gen_1)] = new_gen1
+                    generators[generators.index(gen_2)] = new_gen2
+                    # Remove ROI from Excluder
+                    excluder_.rois.remove(roi_)
+                    if not excluder_.rois:
+                        # Remove Excluder if it is now empty
+                        excluders.remove(excluder_)
 
         for generator in generators:
             generator.prepare_positions()
@@ -114,7 +123,7 @@ class CompoundGenerator(object):
         generators[-1].prepare_bounds()
 
         for excluder in excluders:
-            axis_1, axis_2 = excluder.scannables
+            axis_1, axis_2 = excluder.axes
             gen_1 = [g for g in generators if axis_1 in g.axes][0]
             gen_2 = [g for g in generators if axis_2 in g.axes][0]
             gen_diff = generators.index(gen_1) \

--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -5,6 +5,7 @@ from scanpointgenerator.core.dimension import Dimension
 from scanpointgenerator.core.generator import Generator
 from scanpointgenerator.core.point import Point
 from scanpointgenerator.core.excluder import Excluder
+from scanpointgenerator.excluders.roiexcluder import ROIExcluder
 from scanpointgenerator.core.mutator import Mutator
 from scanpointgenerator.rois import RectangularROI
 from scanpointgenerator.generators import LineGenerator
@@ -76,9 +77,11 @@ class CompoundGenerator(object):
         # we should restrict the resulting grid rather than merge dimensions
         # this changes the alternating case a little (without doing this, we
         # may have started in reverse direction)
-        for excluder_ in excluders:
-            for roi_ in [r for r in excluder_.rois
-                         if isinstance(r, RectangularROI) and r.angle == 0]:
+        for excluder_ in [e for e in excluders if isinstance(e, ROIExcluder)]:
+            rect_rois = [r for r in excluder_.rois
+                         if isinstance(r, RectangularROI) and r.angle == 0]
+            if len(rect_rois) == 1:
+                rect = rect_rois[0]
                 axis_1, axis_2 = excluder_.axes[0], excluder_.axes[1]
                 gen_1 = [g for g in generators if axis_1 in g.axes][0]
                 gen_2 = [g for g in generators if axis_2 in g.axes][0]
@@ -91,15 +94,15 @@ class CompoundGenerator(object):
                     # Filter by axis 1
                     valid = np.full(gen_1.size, True, dtype=np.int8)
                     valid &= \
-                        gen_1.positions[axis_1] <= roi_.width + roi_.start[0]
+                        gen_1.positions[axis_1] <= rect.width + rect.start[0]
                     valid &= \
-                        gen_1.positions[axis_1] >= roi_.start[0]
+                        gen_1.positions[axis_1] >= rect.start[0]
                     points_1 = gen_1.positions[axis_1][valid.astype(np.bool)]
                     # Filter by axis 2
                     valid = np.full(gen_2.size, True, dtype=np.int8)
                     valid &= \
-                        gen_2.positions[axis_2] <= roi_.height + roi_.start[1]
-                    valid &= gen_2.positions[axis_2] >= roi_.start[1]
+                        gen_2.positions[axis_2] <= rect.height + rect.start[1]
+                    valid &= gen_2.positions[axis_2] >= rect.start[1]
                     points_2 = gen_2.positions[axis_2][valid.astype(np.bool)]
                     # Recreate generators to replace larger generators + ROI
                     new_gen1 = LineGenerator(
@@ -111,7 +114,7 @@ class CompoundGenerator(object):
                     generators[generators.index(gen_1)] = new_gen1
                     generators[generators.index(gen_2)] = new_gen2
                     # Remove ROI from Excluder
-                    excluder_.rois.remove(roi_)
+                    excluder_.rois.remove(rect)
                     if not excluder_.rois:
                         # Remove Excluder if it is now empty
                         excluders.remove(excluder_)

--- a/scanpointgenerator/core/dimension.py
+++ b/scanpointgenerator/core/dimension.py
@@ -59,8 +59,8 @@ class Dimension(object):
         if self._prepared:
             raise ValueError("Can not apply excluders after"
                              "prepare has been called")
-        axis_inner = excluder.scannables[0]
-        axis_outer = excluder.scannables[1]
+        axis_inner = excluder.axes[0]
+        axis_outer = excluder.axes[1]
         gen_inner = [g for g in self.generators if axis_inner in g.axes][0]
         gen_outer = [g for g in self.generators if axis_outer in g.axes][0]
         points_x = gen_inner.positions[axis_inner]
@@ -87,7 +87,7 @@ class Dimension(object):
             points_x = np.copy(points_x)
             points_y = np.copy(points_y)
 
-        if axis_inner == excluder.scannables[0]:
+        if axis_inner == excluder.axes[0]:
             excluder_mask = excluder.create_mask(points_x, points_y)
         else:
             excluder_mask = excluder.create_mask(points_y, points_x)

--- a/scanpointgenerator/core/dimension.py
+++ b/scanpointgenerator/core/dimension.py
@@ -81,11 +81,6 @@ class Dimension(object):
         elif gen_inner is not gen_outer:
             points_x = np.repeat(points_x, gen_outer.size)
             points_y = np.tile(points_y, gen_inner.size)
-        else:
-            # copy the point arrays so the excluders can perform
-            # array operations in place (advantageous in the other cases)
-            points_x = np.copy(points_x)
-            points_y = np.copy(points_y)
 
         if axis_inner == excluder.axes[0]:
             excluder_mask = excluder.create_mask(points_x, points_y)

--- a/scanpointgenerator/core/excluder.py
+++ b/scanpointgenerator/core/excluder.py
@@ -4,7 +4,7 @@ class Excluder(object):
 
     """Base class for objects that filter points based on their attributes."""
 
-    # Lookup table for mutator subclasses
+    # Lookup table for excluder subclasses
     _excluder_lookup = {}
 
     def __init__(self, axes):
@@ -33,7 +33,7 @@ class Excluder(object):
             d(dict): Dictionary of attributes
 
         Returns:
-            Mutator: New Mutator instance
+            Excluder: New Excluder instance
 
         """
         excluder_type = d["typeid"]

--- a/scanpointgenerator/core/excluder.py
+++ b/scanpointgenerator/core/excluder.py
@@ -1,64 +1,62 @@
 
 
 class Excluder(object):
-    """
-    A class to remove points that lie outside of a given 2D region of interest
-    """
 
-    def __init__(self, roi, scannables):
+    """Base class for objects that filter points based on their attributes."""
+
+    # Lookup table for mutator subclasses
+    _excluder_lookup = {}
+
+    def __init__(self, axes):
         """
         Args:
-            roi(ROI): Region of interest to filter points by
-            scannables(list): List of two scannables to filter points by
+            axes(list(str)): Names of axes to exclude points from
+
         """
-
-        self.roi = roi
-        self.scannables = scannables
-
-    def contains_point(self, d):
-        """
-        Create a 2D sub-point from the ND point d and pass the sub_point to
-        the roi to check if it contains it.
-
-        Args:
-            d(dict): Dictionary representation of point
-
-        Returns:
-            bool: Whether roi contains the given point
-        """
-
-        scannable_1 = d[self.scannables[0]]
-        scannable_2 = d[self.scannables[1]]
-
-        sub_point = (scannable_1, scannable_2)
-
-        return self.roi.contains_point(sub_point)
+        self.axes = axes
 
     def create_mask(self, x_points, y_points):
-        return self.roi.mask_points([x_points, y_points])
+        raise NotImplementedError("Method must be implemented in child class.")
 
     def to_dict(self):
-        """Convert object attributes into a dictionary"""
-
+        """Construct dictionary from attributes."""
         d = dict()
-        d['roi'] = self.roi.to_dict()
-        d['scannables'] = self.scannables
+        d['axes'] = self.axes
 
         return d
 
     @classmethod
     def from_dict(cls, d):
-        """
-        Create a Excluder instance from a serialised dictionary
+        """Create an Excluder instance from a serialised dictionary.
 
         Args:
             d(dict): Dictionary of attributes
 
         Returns:
-            Excluder: New Excluder instance
+            Mutator: New Mutator instance
+
         """
+        excluder_type = d["typeid"]
+        excluder = cls._excluder_lookup[excluder_type]
+        assert excluder is not cls, \
+            "Subclass %s did not redefine from_dict" % excluder_type
+        excluder = excluder.from_dict(d)
 
-        roi = d['roi'].from_dict()
-        scannables = d['scannables']
+        return excluder
 
-        return cls(roi, scannables)
+    @classmethod
+    def register_subclass(cls, excluder_type):
+        """
+        Register a subclass so from_dict() works
+
+        Args:
+            excluder_type(Excluder): Subclass to register
+
+        """
+        def decorator(excluder):
+            cls._excluder_lookup[excluder_type] = excluder
+            excluder.typeid = excluder_type
+
+            return excluder
+
+        return decorator

--- a/scanpointgenerator/excluders/__init__.py
+++ b/scanpointgenerator/excluders/__init__.py
@@ -1,0 +1,1 @@
+from scanpointgenerator.excluders.roiexcluder import ROIExcluder

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -24,8 +24,8 @@ class ROIExcluder(Excluder):
         The resulting mask is created from the union of all ROIs.
 
         Args:
-            x_points(list(float)): List of points for x-axis
-            y_points(list(float)): List of points for y-axis
+            x_points(numpy.array(float)): Array of points for x-axis
+            y_points(numpy.array(float)): Array of points for y-axis
 
         Returns:
             np.array: Boolean array of points to exclude
@@ -36,9 +36,18 @@ class ROIExcluder(Excluder):
 
         mask = np.zeros_like(x_points, dtype=bool)
         for roi in self.rois:
+            if roi is self.rois[-1]:
+                # Allow operating in place if this is the final ROI
+                x = x_points
+                y = y_points
+            else:
+                # Otherwise use copies of the arrays
+                x = x_points.copy()
+                y = y_points.copy()
+
             # Accumulate all True entries
             # Points outside of all ROIs will be excluded
-            mask |= roi.mask_points([x_points, y_points])
+            mask |= roi.mask_points([x, y])
 
         return mask
 

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -21,6 +21,8 @@ class ROIExcluder(Excluder):
     def create_mask(self, x_points, y_points):
         """Create a boolean array specifying the points to exclude.
 
+        The resulting mask is created from the union of all ROIs.
+
         Args:
             x_points(list(float)): List of points for x-axis
             y_points(list(float)): List of points for y-axis

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -36,12 +36,9 @@ class ROIExcluder(Excluder):
 
         mask = np.zeros_like(x_points, dtype=bool)
         for roi in self.rois:
-            x = x_points.copy()
-            y = y_points.copy()
-
             # Accumulate all True entries
             # Points outside of all ROIs will be excluded
-            mask |= roi.mask_points([x, y])
+            mask |= roi.mask_points([x_points, y_points])
 
         return mask
 

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -36,14 +36,8 @@ class ROIExcluder(Excluder):
 
         mask = np.zeros_like(x_points, dtype=bool)
         for roi in self.rois:
-            if roi is self.rois[-1]:
-                # Allow operating in place if this is the final ROI
-                x = x_points
-                y = y_points
-            else:
-                # Otherwise use copies of the arrays
-                x = x_points.copy()
-                y = y_points.copy()
+            x = x_points.copy()
+            y = y_points.copy()
 
             # Accumulate all True entries
             # Points outside of all ROIs will be excluded

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -28,13 +28,13 @@ class ROIExcluder(Excluder):
             y_points(numpy.array(float)): Array of points for y-axis
 
         Returns:
-            np.array: Boolean array of points to exclude
+            np.array(int8): Array of points to exclude
 
         """
         if len(x_points) != len(y_points):
             raise ValueError("Points lengths must be equal")
 
-        mask = np.zeros_like(x_points, dtype=bool)
+        mask = np.zeros_like(x_points, dtype=np.int8)
         for roi in self.rois:
             # Accumulate all True entries
             # Points outside of all ROIs will be excluded

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -1,0 +1,65 @@
+from scanpointgenerator.core import Excluder, ROI
+from scanpointgenerator.compat import np
+
+
+@Excluder.register_subclass("scanpointgenerator:excluder/ROIExcluder:1.0")
+class ROIExcluder(Excluder):
+
+    """A class to exclude points outside of regions of interest."""
+
+    def __init__(self, rois, axes):
+        """
+        Args:
+            rois(list(ROI)): List of regions of interest
+            axes(list(str)): Names of axes to exclude points from
+
+        """
+        super(ROIExcluder, self).__init__(axes)
+
+        self.rois = rois
+
+    def create_mask(self, x_points, y_points):
+        """Create a boolean array specifying the points to exclude.
+
+        Args:
+            x_points(list(float)): List of points for x-axis
+            y_points(list(float)): List of points for y-axis
+
+        Returns:
+            np.array: Boolean array of points to exclude
+
+        """
+        if len(x_points) != len(y_points):
+            raise ValueError("Points lengths must be equal")
+
+        mask = np.zeros_like(x_points, dtype=bool)
+        for roi in self.rois:
+            # Accumulate all True entries
+            # Points outside of all ROIs will be excluded
+            mask |= roi.mask_points([x_points, y_points])
+
+        return mask
+
+    def to_dict(self):
+        """Construct dictionary from attributes."""
+        d = super(ROIExcluder, self).to_dict()
+        d['typeid'] = self.typeid
+        d['rois'] = [roi.to_dict() for roi in self.rois]
+
+        return d
+
+    @classmethod
+    def from_dict(cls, d):
+        """Create a ROIExcluder from a serialised dictionary.
+
+        Args:
+            d(dict): Dictionary of attributes
+
+        Returns:
+            ROIExcluder: New instance of ROIExcluder
+
+        """
+        rois = [ROI.from_dict(roi_dict) for roi_dict in d['rois']]
+        axes = d['axes']
+
+        return cls(rois, axes)

--- a/scanpointgenerator/plotgenerator.py
+++ b/scanpointgenerator/plotgenerator.py
@@ -10,12 +10,12 @@ def plot_generator(gen, excluder=None, show_indexes=True):
     from scipy import interpolate
 
     if excluder is not None:
-        roi = excluder.roi
-        overlay = plt.subplot(111, aspect='equal')
-        if isinstance(roi, RectangularROI):
-            overlay.add_patch(Rectangle(roi.start, roi.width, roi.height, fill=False))
-        if isinstance(roi, CircularROI):
-            overlay.add_patch(Circle(roi.centre, roi.radius, fill=False))
+        for roi in excluder.rois:
+            overlay = plt.subplot(111, aspect='equal')
+            if isinstance(roi, RectangularROI):
+                overlay.add_patch(Rectangle(roi.start, roi.width, roi.height, fill=False))
+            if isinstance(roi, CircularROI):
+                overlay.add_patch(Circle(roi.centre, roi.radius, fill=False))
 
     if not isinstance(gen, CompoundGenerator):
         excluders = [] if excluder is None else [excluder]

--- a/scanpointgenerator/rois/circular_roi.py
+++ b/scanpointgenerator/rois/circular_roi.py
@@ -22,9 +22,9 @@ class CircularROI(ROI):
             return True
 
     def mask_points(self, points):
-        x = points[0]
+        x = points[0].copy()
         x -= self.centre[0]
-        y = points[1]
+        y = points[1].copy()
         y -= self.centre[1]
         # use in place operations as much as possible (to save array creation)
         x *= x

--- a/scanpointgenerator/rois/elliptical_roi.py
+++ b/scanpointgenerator/rois/elliptical_roi.py
@@ -30,9 +30,9 @@ class EllipticalROI(ROI):
         return (x * x) / (rx * rx) + (y * y) / (ry * ry) <= 1
 
     def mask_points(self, points):
-        x = points[0]
+        x = points[0].copy()
         x -= self.centre[0]
-        y = points[1]
+        y = points[1].copy()
         y -= self.centre[1]
         if self.angle != 0:
             phi = -self.angle

--- a/scanpointgenerator/rois/point_roi.py
+++ b/scanpointgenerator/rois/point_roi.py
@@ -16,9 +16,9 @@ class PointROI(ROI):
         return x * x + y * y <= epsilon * epsilon
 
     def mask_points(self, points, epsilon=0):
-        x = points[0]
+        x = points[0].copy()
         x -= self.point[0]
-        y = points[1]
+        y = points[1].copy()
         y -= self.point[1]
         x *= x
         y *= y

--- a/scanpointgenerator/rois/rectangular_roi.py
+++ b/scanpointgenerator/rois/rectangular_roi.py
@@ -32,9 +32,9 @@ class RectangularROI(ROI):
                 and (y >= 0 and y <= self.height)
 
     def mask_points(self, points):
-        x = points[0]
+        x = points[0].copy()
         x -= self.start[0]
-        y = points[1]
+        y = points[1].copy()
         y -= self.start[1]
         if self.angle != 0:
             phi = -self.angle

--- a/scanpointgenerator/rois/sector_roi.py
+++ b/scanpointgenerator/rois/sector_roi.py
@@ -49,8 +49,8 @@ class SectorROI(ROI):
         return theta <= sweep
 
     def mask_points(self, points):
-        x = points[0]
-        y = points[1]
+        x = points[0].copy()
+        y = points[1].copy()
         x -= self.centre[0]
         y -= self.centre[1]
         r2 = (np.square(x) + np.square(y))

--- a/tests/test_core/test_compoundgenerator.py
+++ b/tests/test_core/test_compoundgenerator.py
@@ -8,7 +8,7 @@ from scanpointgenerator import CompoundGenerator
 from scanpointgenerator import LineGenerator
 from scanpointgenerator import SpiralGenerator
 from scanpointgenerator import LissajousGenerator
-from scanpointgenerator import Excluder
+from scanpointgenerator import ROIExcluder
 from scanpointgenerator.rois import CircularROI, RectangularROI, EllipticalROI, SectorROI
 from scanpointgenerator.mutators import RandomOffsetMutator
 from scanpointgenerator.compat import range_
@@ -79,7 +79,7 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         y = LineGenerator("y", "mm", -1., 1, 5, False)
         z = LineGenerator("z", "mm", -1., 1, 5, False)
         r = CircularROI([0., 0.], 1)
-        e = Excluder(r, ["x", "y"])
+        e = ROIExcluder([r], ["x", "y"])
         g = CompoundGenerator([z, y, x], [e], [])
         g.prepare()
         points = [g.get_point(n) for n in range(0, g.size)]
@@ -103,13 +103,13 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         t = LineGenerator("t", "mm", 0, 1, 5)
         rad1 = 2.8
         r1 = CircularROI([1., 1.], rad1)
-        e1 = Excluder(r1, ["x", "y"])
+        e1 = ROIExcluder([r1], ["x", "y"])
         rad2 = 2
         r2 = CircularROI([0.5, 0.5], rad2)
-        e2 = Excluder(r2, ["y", "z"])
+        e2 = ROIExcluder([r2], ["y", "z"])
         rad3 = 0.5
         r3 = CircularROI([0.5, 0.5], rad3)
-        e3 = Excluder(r3, ["w", "t"])
+        e3 = ROIExcluder([r3], ["w", "t"])
         g = CompoundGenerator([t, w, z, s], [e1, e2, e3], [])
         g.prepare()
 
@@ -187,7 +187,7 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         y = LineGenerator("y", "mm", 1, 5, 5, True)
         x = LineGenerator("x", "mm", 1, 5, 5, True)
         r1 = CircularROI([3, 3], 1.5)
-        e1 = Excluder(r1, ["y", "x"])
+        e1 = ROIExcluder([r1], ["y", "x"])
         g = CompoundGenerator([y, x], [e1], [])
         g.prepare()
         expected = []
@@ -210,7 +210,7 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         y = LineGenerator("y", "mm", 1, 5, 5, alternate=True)
         x = LineGenerator("x", "mm", 1, 5, 5, alternate=True)
         r1 = CircularROI([3, 3], 1.5)
-        e1 = Excluder(r1, ["x", "y"])
+        e1 = ROIExcluder([r1], ["x", "y"])
         g = CompoundGenerator([z, y, x], [e1], [])
         g.prepare()
         expected = []
@@ -246,8 +246,8 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         xg = LineGenerator("x", "mm", 0, 1, 2, True)
         r1 = EllipticalROI([0, 1], [1, 2])
         r2 = SectorROI([0, 0], [0.2, 1], [0, 7])
-        e1 = Excluder(r1, ['x', 'y'])
-        e2 = Excluder(r2, ['w', 'z'])
+        e1 = ROIExcluder([r1], ['x', 'y'])
+        e2 = ROIExcluder([r2], ['w', 'z'])
         g = CompoundGenerator([wg, zg, yg, xg], [e1, e2], [])
         g.prepare()
         actual = [p.positions for p in g.iterator()]
@@ -264,8 +264,8 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         yg = LineGenerator("y", "mm", 0, 4, 5)
         xg = LineGenerator("x", "mm", 0, 4, 5)
         r1 = CircularROI([0, 0], 1)
-        e1 = Excluder(r1, ["s1", "z"])
-        e2 = Excluder(r1, ["y", "x"])
+        e1 = ROIExcluder([r1], ["s1", "z"])
+        e2 = ROIExcluder([r1], ["y", "x"])
         g = CompoundGenerator([tg, zg, spiral, yg, xg], [e2, e1], [])
         g.prepare()
 
@@ -297,8 +297,8 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         xg = LineGenerator("x", "mm", 0, 4, 5, True)
         r1 = RectangularROI([-1, -1], 5.5, 3.5)
         r2 = RectangularROI([1, 0], 2.5, 2.5)
-        e1 = Excluder(r1, ["z", "y"])
-        e2 = Excluder(r2, ["x", "y"])
+        e1 = ROIExcluder([r1], ["z", "y"])
+        e2 = ROIExcluder([r2], ["x", "y"])
         g = CompoundGenerator([tg, zg, yg, xg], [e1, e2], [])
         g.prepare()
         zf = True
@@ -329,8 +329,8 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         y = LineGenerator("y", "mm", 1, 5, 5, True)
         x = LineGenerator("x", "mm", 1, 5, 5, True)
         r1 = CircularROI([3, 3], 1.5)
-        e1 = Excluder(r1, ["x", "y"])
-        e2 = Excluder(r1, ["z", "y"])
+        e1 = ROIExcluder([r1], ["x", "y"])
+        e2 = ROIExcluder([r1], ["z", "y"])
         g = CompoundGenerator([z, y, x], [e1, e2], []) #20 points
         g.prepare()
         actual = [p.positions for p in list(g.iterator())]
@@ -357,8 +357,8 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         yg = LineGenerator("y", "mm", 1, 5, 5, True)
         xg = LineGenerator("x", "mm", 1, 5, 5, True)
         r1 = RectangularROI([3., 3.], 2., 2.)
-        e1 = Excluder(r1, ["y", "x"])
-        e2 = Excluder(r1, ["z", "y"])
+        e1 = ROIExcluder([r1], ["y", "x"])
+        e2 = ROIExcluder([r1], ["z", "y"])
         g = CompoundGenerator([tg, zg, yg, xg], [e1, e2], [])
         g.debug = True
         g.prepare()
@@ -440,9 +440,9 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         r1 = CircularROI([1, 1], 2)
         r2 = CircularROI([-1, -1], 4)
         r3 = CircularROI([1, 1], 2)
-        e1 = Excluder(r1, ["j1", "l2"])
-        e2 = Excluder(r2, ["s2", "l1"])
-        e3 = Excluder(r3, ["s1", "s2"])
+        e1 = ROIExcluder([r1], ["j1", "l2"])
+        e2 = ROIExcluder([r2], ["s2", "l1"])
+        e3 = ROIExcluder([r3], ["s1", "s2"])
         g = CompoundGenerator([lissajous, line2, line1, spiral], [e1, e2, e3], [])
         g.prepare()
 
@@ -485,8 +485,8 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         spiral_t = SpiralGenerator(["t1", "t2"], "mm", [0, 0], 5, 2.5, True)
         line2 = LineGenerator(["l2"], "mm", -1, 2, 5, True)
         r = CircularROI([0, 0], 1)
-        e1 = Excluder(r, ["s1", "l1"])
-        e2 = Excluder(r, ["l2", "t1"])
+        e1 = ROIExcluder([r], ["s1", "l1"])
+        e2 = ROIExcluder([r], ["l2", "t1"])
         g = CompoundGenerator([line1, spiral_s, spiral_t, line2], [e1, e2], [])
         g.prepare()
 
@@ -561,7 +561,7 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         xg = LineGenerator("x", "mm", 1, 10, 10)
         yg = LineGenerator("y", "mm", 1, 10, 10)
         r = RectangularROI([3, 3], 6, 6)
-        e = Excluder(r, ["x", "y"])
+        e = ROIExcluder([r], ["x", "y"])
         g = CompoundGenerator([yg, xg], [e], [])
         g.prepare()
         self.assertEqual(49, g.size)
@@ -598,7 +598,7 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         x = LineGenerator("x", "mm", 0, 1, 5, False)
         y = LineGenerator("y", "mm", 0, 1, 5, False)
         circle = CircularROI([0., 0.], 1)
-        excluder = Excluder(circle, ['x', 'y'])
+        excluder = ROIExcluder([circle], ['x', 'y'])
         g = CompoundGenerator([y, x], [excluder], [])
         g.prepare()
         self.assertEqual(1, len(g.dimensions))
@@ -612,7 +612,7 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         x = LineGenerator("x", "mm", -1.0, 1.0, 5, False)
         y = LineGenerator("y", "mm", -1.0, 1.0, 5, False)
         r = CircularROI([0, 0], 1)
-        e = Excluder(r, ["x", "y"])
+        e = ROIExcluder([r], ["x", "y"])
         g = CompoundGenerator([y, x], [e], [])
         g.prepare()
         p = [(x/2., y/2.) for y in range_(-2, 3) for x in range_(-2, 3)]
@@ -623,7 +623,7 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         x = LineGenerator("x", "mm", -1.0, 1.0, 5, alternate=True)
         y = LineGenerator("y", "mm", -1.0, 1.0, 5, alternate=True)
         r = CircularROI([0.5, 0], 1)
-        e = Excluder(r, ["x", "y"])
+        e = ROIExcluder([r], ["x", "y"])
         g = CompoundGenerator([y, x], [e], [])
         g.prepare()
         reverse = False
@@ -642,8 +642,8 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         spiral = SpiralGenerator(['x', 'y'], "mm", [0.0, 0.0], 3, alternate=True) #29 points
         r1 = RectangularROI([-2, -2], 4, 3)
         r2 = RectangularROI([-2, 0], 4, 3)
-        e1 = Excluder(r1, ["y", "x"])
-        e2 = Excluder(r2, ["y", "z"])
+        e1 = ROIExcluder([r1], ["y", "x"])
+        e2 = ROIExcluder([r2], ["y", "z"])
         g = CompoundGenerator([zgen, spiral], [e1, e2], [])
         g.prepare()
         xy = list(zip(spiral.positions['x'], spiral.positions['y']))
@@ -660,8 +660,8 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         spiral = SpiralGenerator(['x', 'y'], "mm", [0.0, 0.0], 3) #29 points
         r1 = RectangularROI([-2, -2], 4, 3)
         r2 = RectangularROI([-2, 0], 4, 3)
-        e1 = Excluder(r1, ["y", "x"])
-        e2 = Excluder(r2, ["y", "z"])
+        e1 = ROIExcluder([r1], ["y", "x"])
+        e2 = ROIExcluder([r2], ["y", "z"])
         g = CompoundGenerator([zgen, spiral], [e1, e2], [])
         g.prepare()
         p = list(zip(spiral.positions['x'], spiral.positions['y']))
@@ -675,7 +675,7 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         z = LineGenerator("z", "mm", 0.0, 4.0, 5)
         spiral = SpiralGenerator(['x', 'y'], "mm", [0.0, 0.0], 3, alternate=True) #29 points
         r = RectangularROI([-2, -2], 3, 4)
-        e = Excluder(r, ["x", "y"])
+        e = ROIExcluder([r], ["x", "y"])
         g = CompoundGenerator([z, spiral], [e], [])
         g.prepare()
         p = list(zip(spiral.positions['x'], spiral.positions['y']))
@@ -689,8 +689,8 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         y = LineGenerator("y", "mm", -1.0, 1.0, 5, False)
         z = LineGenerator("z", "mm", -1.0, 1.0, 5, False)
         r = CircularROI([0.1, 0.2], 1)
-        e1 = Excluder(r, ["x", "y"])
-        e2 = Excluder(r, ["y", "z"])
+        e1 = ROIExcluder([r], ["x", "y"])
+        e2 = ROIExcluder([r], ["y", "z"])
         g = CompoundGenerator([z, y, x], [e1, e2], [])
         g.prepare()
         p = [(x/2., y/2., z/2.) for z in range_(-2, 3)
@@ -707,8 +707,8 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         yg = LineGenerator("y", "mm", 1, 5, 5, alternate=True)
         xg = LineGenerator("x", "mm", 2, 6, 5, alternate=True)
         r1 = CircularROI([4., 4.], 1.5)
-        e1 = Excluder(r1, ["y", "x"])
-        e2 = Excluder(r1, ["z", "y"])
+        e1 = ROIExcluder([r1], ["y", "x"])
+        e2 = ROIExcluder([r1], ["z", "y"])
         g = CompoundGenerator([tg, zg, yg, xg], [e1, e2], [])
         g.prepare()
 
@@ -738,11 +738,11 @@ class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
         x3 = LineGenerator("x3", "mm", 0, 1.0, 5, False)
         y3 = LineGenerator("y3", "mm", 0, 1.0, 5, False)
         r = CircularROI([0, 0], 1)
-        e1 = Excluder(r, ["x1", "y1"])
-        e2 = Excluder(r, ["y1", "z1"])
-        e3 = Excluder(r, ["x1", "y1"])
-        e4 = Excluder(r, ["x2", "y2"])
-        e5 = Excluder(r, ["x3", "y3"])
+        e1 = ROIExcluder([r], ["x1", "y1"])
+        e2 = ROIExcluder([r], ["y1", "z1"])
+        e3 = ROIExcluder([r], ["x1", "y1"])
+        e4 = ROIExcluder([r], ["x2", "y2"])
+        e5 = ROIExcluder([r], ["x3", "y3"])
         g = CompoundGenerator(
                 [x3, y3, y2, x2, z1, y1, x1],
                 [e1, e2, e3, e4, e5],

--- a/tests/test_core/test_compoundgenerator.py
+++ b/tests/test_core/test_compoundgenerator.py
@@ -575,6 +575,19 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         self.assertEqual([2, 0], p.indexes)
         self.assertEqual((5, 3), (p.positions['y'], p.positions['x']))
 
+        self.assertEqual(0, len(g.excluders[0].rois))
+
+    def test_grid_double_rect_region_then_not_reduced(self):
+        xg = LineGenerator("x", "mm", 1, 10, 10)
+        yg = LineGenerator("y", "mm", 1, 10, 10)
+        r1 = RectangularROI([3, 3], 6, 6)
+        r2 = RectangularROI([3, 3], 6, 6)
+        e = ROIExcluder([r1, r2], ["x", "y"])
+        g = CompoundGenerator([yg, xg], [e], [])
+        g.prepare()
+
+        self.assertEqual(2, len(g.excluders[0].rois))
+
     def test_multi_roi_excluder(self):
         x = LineGenerator("x", "mm", 0.0, 4.0, 5, alternate=True)
         y = LineGenerator("y", "mm", 0.0, 3.0, 4)
@@ -591,9 +604,7 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
                               {'x': 2.0, 'y': 3.0},
                               {'x': 1.0, 'y': 3.0},
                               {'x': 0.0, 'y': 3.0}]
-# Write two tests above
-# Ask if each excluder can have rect
-# Ask best solution to masking in place
+
         g = CompoundGenerator([y, x], [circles], [])
         g.prepare()
         positions = [point.positions for point in list(g.iterator())]

--- a/tests/test_core/test_compoundgenerator.py
+++ b/tests/test_core/test_compoundgenerator.py
@@ -575,8 +575,6 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         self.assertEqual([2, 0], p.indexes)
         self.assertEqual((5, 3), (p.positions['y'], p.positions['x']))
 
-        self.assertEqual(0, len(g.excluders[0].rois))
-
     def test_grid_double_rect_region_then_not_reduced(self):
         xg = LineGenerator("x", "mm", 1, 10, 10)
         yg = LineGenerator("y", "mm", 1, 10, 10)

--- a/tests/test_core/test_compoundgenerator.py
+++ b/tests/test_core/test_compoundgenerator.py
@@ -575,6 +575,31 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         self.assertEqual([2, 0], p.indexes)
         self.assertEqual((5, 3), (p.positions['y'], p.positions['x']))
 
+    def test_multi_roi_excluder(self):
+        x = LineGenerator("x", "mm", 0.0, 4.0, 5, alternate=True)
+        y = LineGenerator("y", "mm", 0.0, 3.0, 4)
+        circles = ROIExcluder([CircularROI([1.0, 2.0], 2.0),
+                               CircularROI([1.0, 2.0], 2.0)], ["x", "y"])
+        expected_positions = [{'x': 1.0, 'y': 0.0},
+                              {'x': 2.0, 'y': 1.0},
+                              {'x': 1.0, 'y': 1.0},
+                              {'x': 0.0, 'y': 1.0},
+                              {'x': 0.0, 'y': 2.0},
+                              {'x': 1.0, 'y': 2.0},
+                              {'x': 2.0, 'y': 2.0},
+                              {'x': 3.0, 'y': 2.0},
+                              {'x': 2.0, 'y': 3.0},
+                              {'x': 1.0, 'y': 3.0},
+                              {'x': 0.0, 'y': 3.0}]
+# Write two tests above
+# Ask if each excluder can have rect
+# Ask best solution to masking in place
+        g = CompoundGenerator([y, x], [circles], [])
+        g.prepare()
+        positions = [point.positions for point in list(g.iterator())]
+
+        self.assertEqual(positions, expected_positions)
+
 class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
     """Tests on datastructures internal to CompoundGenerator"""
 

--- a/tests/test_core/test_compoundgenerator_performance.py
+++ b/tests/test_core/test_compoundgenerator_performance.py
@@ -8,7 +8,7 @@ from test_util import ScanPointGeneratorTest
 from scanpointgenerator import CompoundGenerator
 from scanpointgenerator import LineGenerator
 from scanpointgenerator import SpiralGenerator
-from scanpointgenerator import Excluder
+from scanpointgenerator import ROIExcluder
 from scanpointgenerator.rois import CircularROI
 from scanpointgenerator.mutators import RandomOffsetMutator
 
@@ -23,9 +23,9 @@ class CompoundGeneratorPerformanceTest(ScanPointGeneratorTest):
         r1 = CircularROI([-0.7, 4], 0.5)
         r2 = CircularROI([0.5, 0.5], 0.3)
         r3 = CircularROI([0.2, 4], 0.5)
-        e1 = Excluder(r1, ["x", "y"])
-        e2 = Excluder(r2, ["w", "z"])
-        e3 = Excluder(r3, ["z", "y"])
+        e1 = ROIExcluder([r1], ["x", "y"])
+        e2 = ROIExcluder([r2], ["w", "z"])
+        e3 = ROIExcluder([r3], ["z", "y"])
         om = RandomOffsetMutator(0, ["x", "y"], {"x":0.2, "y":0.2})
         g = CompoundGenerator([w, z, s], [e1, e3, e2], [om])
         g.prepare() # g.size ~3e5

--- a/tests/test_core/test_dimension.py
+++ b/tests/test_core/test_dimension.py
@@ -119,7 +119,7 @@ class DimensionTests(ScanPointGeneratorTest):
         g = Mock(axes=["x", "y"], positions={"x":x_pos, "y":y_pos})
         g.alternate = False
         mask = np.array([1, 1, 0, 1, 0, 0], dtype=np.int8)
-        e = Mock(scannables=["x", "y"], create_mask=Mock(return_value=mask))
+        e = Mock(axes=["x", "y"], create_mask=Mock(return_value=mask))
         d = Dimension(g)
         d.apply_excluder(e)
         d._masks[0]["mask"] = d._masks[0]["mask"].tolist()
@@ -133,7 +133,7 @@ class DimensionTests(ScanPointGeneratorTest):
         hx_pos = np.zeros(5)
         hy_pos = np.array([-1, -2, -3])
         mask = np.full(15, 1, dtype=np.int8)
-        e = Mock(scannables=["gx", "hy"], create_mask=Mock(return_value=mask))
+        e = Mock(axes=["gx", "hy"], create_mask=Mock(return_value=mask))
         g = Mock(axes=["gx", "gy"], positions={"gx":gx_pos, "gy":gy_pos}, size=len(gx_pos), alternate=False)
         h = Mock(axes=["hx", "hy"], positions={"hx":hx_pos, "hy":hy_pos}, size=len(hy_pos), alternate=False)
         d = Dimension(g)
@@ -151,7 +151,7 @@ class DimensionTests(ScanPointGeneratorTest):
         g = Mock(axes=["x", "y"], positions={"x":x_pos, "y":y_pos})
         g.alternate = True
         mask = np.array([1, 1, 0, 1, 0, 0], dtype=np.int8)
-        e = Mock(scannables=["x", "y"], create_mask=Mock(return_value=mask))
+        e = Mock(axes=["x", "y"], create_mask=Mock(return_value=mask))
         d = Dimension(g)
         d.apply_excluder(e)
         d._masks[0]["mask"] = d._masks[0]["mask"].tolist()
@@ -165,7 +165,7 @@ class DimensionTests(ScanPointGeneratorTest):
         mask_func = lambda px, py: np.full(len(px), 1, dtype=np.int8)
         g1 = Mock(axes=["g1"], positions={"g1":g1_pos}, size=len(g1_pos))
         g2 = Mock(axes=["g2"], positions={"g2":g2_pos}, size=len(g2_pos))
-        e = Mock(scannables=["g1", "g2"], create_mask=Mock(side_effect=mask_func))
+        e = Mock(axes=["g1", "g2"], create_mask=Mock(side_effect=mask_func))
         d = Dimension(g1)
         d.alternate = True
         d.generators = [Mock(size=5, axes=[]), g1, g2, Mock(size=7, axes=[])]
@@ -182,7 +182,7 @@ class DimensionTests(ScanPointGeneratorTest):
         gy_pos = np.repeat(np.array([0, 1, 2, 3]), 4)
         mask_func = lambda px, py: (px-1)**2 + (py-2)**2 <= 1
         g = Mock(axes=["gx", "gy"], positions={"gx":gx_pos, "gy":gy_pos}, size=16, alternate=False)
-        e = Mock(scannables=["gx", "gy"], create_mask=Mock(side_effect=mask_func))
+        e = Mock(axes=["gx", "gy"], create_mask=Mock(side_effect=mask_func))
         d = Dimension(g)
         d.apply_excluder(e)
         d.prepare()
@@ -195,7 +195,7 @@ class DimensionTests(ScanPointGeneratorTest):
         mask_func = lambda px, py: (px-1)**2 + (py-2)**2 <= 1
         gx = Mock(axes=["gx"], positions={"gx":gx_pos}, size=4, alternate=False)
         gy = Mock(axes=["gy"], positions={"gy":gy_pos}, size=4, alternate=False)
-        e = Mock(scannables=["gx", "gy"], create_mask=Mock(side_effect=mask_func))
+        e = Mock(axes=["gx", "gy"], create_mask=Mock(side_effect=mask_func))
         dx = Dimension(gx)
         dy = Dimension(gy)
         d = Dimension.merge_dimensions(dy, dx)
@@ -210,8 +210,8 @@ class DimensionTests(ScanPointGeneratorTest):
         gz_pos = np.array([0, 1, 2, 3])
         mask_xy_func = lambda px, py: (px-1)**2 + (py-2)**2 <= 2
         mask_yz_func = lambda py, pz: (py-2)**2 + (pz-1)**2 <= 1
-        exy = Mock(scannables=["gx", "gy"], create_mask=Mock(side_effect=mask_xy_func))
-        eyz = Mock(scannables=["gy", "gz"], create_mask=Mock(side_effect=mask_yz_func))
+        exy = Mock(axes=["gx", "gy"], create_mask=Mock(side_effect=mask_xy_func))
+        eyz = Mock(axes=["gy", "gz"], create_mask=Mock(side_effect=mask_yz_func))
         gx = Mock(axes=["gx"], positions={"gx":gx_pos}, size=4, alternate=True)
         gy = Mock(axes=["gy"], positions={"gy":gy_pos}, size=4, alternate=True)
         gz = Mock(axes=["gz"], positions={"gz":gz_pos}, size=4, alternate=True)

--- a/tests/test_core/test_excluder.py
+++ b/tests/test_core/test_excluder.py
@@ -13,55 +13,41 @@ from mock import MagicMock
 
 class ExcluderTest(unittest.TestCase):
 
-    def setUp(self):
-        self.roi = MagicMock()
-        self.scannables = ['x', 'y']
-        self.e = Excluder(self.roi, self.scannables)
-
     def test_init(self):
-        self.assertEqual(self.e.roi, self.roi)
-        self.assertEqual(self.e.scannables, self.scannables)
-
-    def test_contains_point(self):
-        d = dict()
-        d['x'] = 1.0
-        d['y'] = 2.0
-
-        self.e.contains_point(d)
-
-        self.roi.contains_point.assert_called_once_with((1.0, 2.0))
+        Excluder(["x", "y"])
 
 
-class TestSerialisation(unittest.TestCase):
+class SimpleFunctionsTest(unittest.TestCase):
 
     def setUp(self):
-        self.r1 = MagicMock()
-        self.r1_dict = MagicMock()
+        self.e = Excluder(["x", "y"])
 
-        self.e = Excluder(self.r1, ['x', 'y'])
+    def test_create_mask(self):
+        with self.assertRaises(NotImplementedError):
+            self.e.create_mask(MagicMock(), MagicMock())
+
+
+class SerialisationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.e = Excluder(["x", "y"])
 
     def test_to_dict(self):
-        self.r1.to_dict.return_value = self.r1_dict
-
         expected_dict = dict()
-        expected_dict['roi'] = self.r1_dict
-        expected_dict['scannables'] = ['x', 'y']
+        expected_dict['axes'] = ["x", "y"]
 
         d = self.e.to_dict()
 
         self.assertEqual(expected_dict, d)
 
     def test_from_dict(self):
-        self.r1_dict.from_dict.return_value = self.r1
+        m = MagicMock()
+        self.e._excluder_lookup['TestMutator'] = m
 
-        _dict = dict()
-        _dict['roi'] = self.r1_dict
-        _dict['scannables'] = ['x', 'y']
+        gen_dict = dict(typeid="TestMutator")
+        self.e.from_dict(gen_dict)
 
-        e = Excluder.from_dict(_dict)
-
-        self.assertEqual(e.roi, self.r1)
-        self.assertEqual(e.scannables, ['x', 'y'])
+        m.from_dict.assert_called_once_with(gen_dict)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_excluders/test_roiexcluder.py
+++ b/tests/test_excluders/test_roiexcluder.py
@@ -17,9 +17,9 @@ class TestCreateMask(unittest.TestCase):
         self.r2 = MagicMock()
         self.e = ROIExcluder([self.r1, self.r2], ["x", "y"])
 
-    def test_create_mask_returns_union_of_ROIs(self):
-        x_points = [1, 2, 3, 4]
-        y_points = [10, 10, 20, 20]
+    def test_create_mask_returns_union_of_rois(self):
+        x_points = np.array([1, 2, 3, 4])
+        y_points = np.array([10, 10, 20, 20])
         self.r1.mask_points.return_value = \
             np.array([True, False, False, True])
         self.r2.mask_points.return_value = \
@@ -28,8 +28,12 @@ class TestCreateMask(unittest.TestCase):
 
         mask = self.e.create_mask(x_points, y_points)
 
-        self.r1.mask_points.assert_called_once_with([x_points, y_points])
-        self.r2.mask_points.assert_called_once_with([x_points, y_points])
+        r1_call_list = self.r1.mask_points.call_args_list[0][0][0]
+        r2_call_list = self.r2.mask_points.call_args_list[0][0][0]
+        self.assertEqual(x_points.tolist(), r1_call_list[0].tolist())
+        self.assertEqual(y_points.tolist(), r1_call_list[1].tolist())
+        self.assertEqual(x_points.tolist(), r2_call_list[0].tolist())
+        self.assertEqual(y_points.tolist(), r2_call_list[1].tolist())
         self.assertEqual(expected_mask.tolist(), mask.tolist())
 
 

--- a/tests/test_excluders/test_roiexcluder.py
+++ b/tests/test_excluders/test_roiexcluder.py
@@ -17,7 +17,7 @@ class TestCreateMask(unittest.TestCase):
         self.r2 = MagicMock()
         self.e = ROIExcluder([self.r1, self.r2], ["x", "y"])
 
-    def test_mask_points_called_on_rois(self):
+    def test_create_mask_returns_union_of_ROIs(self):
         x_points = [1, 2, 3, 4]
         y_points = [10, 10, 20, 20]
         self.r1.mask_points.return_value = \
@@ -30,7 +30,7 @@ class TestCreateMask(unittest.TestCase):
 
         self.r1.mask_points.assert_called_once_with([x_points, y_points])
         self.r2.mask_points.assert_called_once_with([x_points, y_points])
-        np.testing.assert_array_equal(expected_mask, mask)
+        self.assertEqual(expected_mask.tolist(), mask.tolist())
 
 
 class TestSerialisation(unittest.TestCase):

--- a/tests/test_excluders/test_roiexcluder.py
+++ b/tests/test_excluders/test_roiexcluder.py
@@ -1,0 +1,70 @@
+import unittest
+
+from pkg_resources import require
+require("mock")
+from mock import MagicMock, patch, call
+
+from scanpointgenerator import ROIExcluder
+from scanpointgenerator.compat import np
+
+roi_patch_path = "scanpointgenerator.core.ROI"
+
+
+class TestCreateMask(unittest.TestCase):
+
+    def setUp(self):
+        self.r1 = MagicMock()
+        self.r2 = MagicMock()
+        self.e = ROIExcluder([self.r1, self.r2], ["x", "y"])
+
+    def test_mask_points_called_on_rois(self):
+        x_points = [1, 2, 3, 4]
+        y_points = [10, 10, 20, 20]
+        self.r1.mask_points.return_value = \
+            np.array([True, False, False, True])
+        self.r2.mask_points.return_value = \
+            np.array([False, False, True, True])
+        expected_mask = np.array([True, False, True, True])
+
+        mask = self.e.create_mask(x_points, y_points)
+
+        self.r1.mask_points.assert_called_once_with([x_points, y_points])
+        self.r2.mask_points.assert_called_once_with([x_points, y_points])
+        np.testing.assert_array_equal(expected_mask, mask)
+
+
+class TestSerialisation(unittest.TestCase):
+
+    def setUp(self):
+        self.r1 = MagicMock()
+        self.r1_dict = MagicMock()
+        self.r2 = MagicMock()
+        self.r2_dict = MagicMock()
+        self.r1.to_dict.return_value = self.r1_dict
+        self.r2.to_dict.return_value = self.r2_dict
+
+        self.e = ROIExcluder([self.r1, self.r2], ["x", "y"])
+
+    def test_to_dict(self):
+        expected_dict = dict()
+        expected_dict['typeid'] = "scanpointgenerator:excluder/ROIExcluder:1.0"
+        expected_dict['rois'] = [self.r1_dict, self.r2_dict]
+        expected_dict['axes'] = ["x", "y"]
+
+        d = self.e.to_dict()
+
+        self.assertEqual(expected_dict, d)
+
+    @patch(roi_patch_path + '.from_dict')
+    def test_from_dict(self, from_dict_mock):
+        from_dict_mock.side_effect = [self.r1, self.r2]
+        _dict = dict()
+        _dict['rois'] = [self.r1_dict, self.r2_dict]
+        _dict['axes'] = ["x", "y"]
+
+        e = ROIExcluder.from_dict(_dict)
+
+        from_dict_mock.assert_has_calls([call(self.r1_dict),
+                                         call(self.r2_dict)])
+        self.assertEqual(e.rois, [self.r1, self.r2])
+        self.assertEqual(e.axes, ["x", "y"])

--- a/tests/test_rois/test_circular_roi.py
+++ b/tests/test_rois/test_circular_roi.py
@@ -43,9 +43,11 @@ class ContainsPointTest(unittest.TestCase):
 
     def test_mask_points(self):
         points = [np.array([7., 9.]), np.array([11., 11.])]
+        points_cp = [axis.copy().tolist() for axis in points]
         expected = [True, False]
         mask = self.roi.mask_points(points)
         self.assertEqual(expected, mask.tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in points])
 
 
 class DictTest(unittest.TestCase):

--- a/tests/test_rois/test_elliptical_roi.py
+++ b/tests/test_rois/test_elliptical_roi.py
@@ -59,8 +59,10 @@ class EllipticalROITest(unittest.TestCase):
         roi = EllipticalROI([1, 2], [2, 1], pi/6)
         points = [np.array([3, 1, 2.73, 3.00, -0.73]),
                   np.array([1, 0, 3.00, 4.27, 1.000])]
+        points_cp = [axis.copy().tolist() for axis in points]
         expected = [False, False, True, False, True]
         self.assertEquals(expected, roi.mask_points(points).tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in points])
 
     def test_to_dict(self):
         roi = EllipticalROI([1.1, 2.2], [3.3, 4.4], pi/4)

--- a/tests/test_rois/test_linear_roi.py
+++ b/tests/test_rois/test_linear_roi.py
@@ -89,9 +89,11 @@ class LinearROIContainsTest(unittest.TestCase):
         px = [1, 2,  3, 1+1e-10, 3-1e-10, 2+1e-10, 2-1e-14,  3+1e-14, 1]
         py = [1, 0, -1, 1      , -1     , 0+1e-10, 0+1e-14, -1-1e-14, 1+1e-14]
         p = [np.array(px), np.array(py)]
+        points_cp = [axis.copy().tolist() for axis in p]
         expected = [True, True, True, False, False, False, True, True, True]
         mask = l.mask_points(p, 1e-12)
         self.assertEquals(expected, mask.tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in p])
 
 class LinearROIDictTest(unittest.TestCase):
 

--- a/tests/test_rois/test_point_roi.py
+++ b/tests/test_rois/test_point_roi.py
@@ -37,12 +37,15 @@ class PointROITest(unittest.TestCase):
         px = [1, 0, 1+1e-15, 1,       1]
         py = [2, 0, 2,       2+1e-15, 2+1e-14]
         expected = [True, False, True, True, False]
-        mask = roi.mask_points([np.array(px), np.array(py)], 2e-15)
+        p = [np.array(px), np.array(py)]
+        points_cp = [axis.copy().tolist() for axis in p]
+        mask = roi.mask_points(p, 2e-15)
         self.assertEqual(expected, mask.tolist())
 
         mask = roi.mask_points([np.array(px), np.array(py)], 0)
         expected = [True, False, False, False, False]
         self.assertEqual(expected, mask.tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in p])
 
     def test_to_dict(self):
         roi = PointROI([1.1, 2.2])

--- a/tests/test_rois/test_polygonal_roi.py
+++ b/tests/test_rois/test_polygonal_roi.py
@@ -72,10 +72,12 @@ class PolygonalROITests(unittest.TestCase):
         px = [0.5, 0.5, 1.5, 1.5, 2.5,  2.5, 3.5, -0.5, 3.5, 2, 3, 0]
         py = [0.5, 2.5, 1.5, 2.5, 2.5, -0.5, 1.5,  0.5, 0.5, 0, 2, 1.5]
         p = [np.array(px), np.array(py)]
+        points_cp = [axis.copy().tolist() for axis in p]
         expected = [True, False, False, True, True, False, False, False, False,
                     True, False, True]
         mask = roi.mask_points(p)
         self.assertEquals(expected, mask.tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in p])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_rois/test_rectangular_roi.py
+++ b/tests/test_rois/test_rectangular_roi.py
@@ -95,9 +95,11 @@ class ContainsPointTest(unittest.TestCase):
         roi = RectangularROI([1, 2], 1, 1, pi/4)
         points = [np.array([2, 2, 1, 1, 1.7, 0.3, 1.01, 0.99]),
                   np.array([3, 2, 2, 3.4, 2.7, 2.705, 1.99, 1.99])]
+        points_cp = [axis.copy().tolist() for axis in points]
         expected = [False, False, True, True, True, True, False, False]
         mask = roi.mask_points(points)
         self.assertEqual(expected, mask.tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in points])
 
 class DictTest(unittest.TestCase):
 

--- a/tests/test_rois/test_sector_roi.py
+++ b/tests/test_rois/test_sector_roi.py
@@ -146,16 +146,18 @@ class SectorContainsTest(unittest.TestCase):
         self.assertTrue(s.contains_point(p))
 
     def test_mask_points(self):
-        s = SectorROI((0, 0), (1, 2), (-pi/2, pi/2))
+        s = SectorROI((0, 1), (1, 2), (-pi/2, pi/2))
         p = [np.array([0, 1, 0, 2.05, 1, 0.7, -1.5, 0.00]),
              np.array([0, 0, 1, 0.00, 1, 0.7, 0.00, 2.05])]
-        expected = [False, True, True, False, True, False, False, False]
+        points_cp = [axis.copy().tolist() for axis in p]
+        expected = [True, True, False, False, True, False, False, True]
         mask = s.mask_points(p)
         self.assertEquals(expected, mask.tolist())
 
         s2 = SectorROI((0, 0), (1, 2), (-5*pi/2, -3*pi/2)) #the same sector
         mask = s.mask_points(p)
         self.assertEquals(expected, mask.tolist())
+        self.assertEqual(points_cp, [axis.tolist() for axis in p])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
ROIExcluder is equivalent to the old Excluder except:
    * It takes a list of ROIs instead only one
    * Scannables has been renamed to axes
    * There is no contains_point method - it is no longer required

The main thing to check is the grid in a rectangular ROI edge case for loop. It has been adjusted to account for the excluder now having another level. Otherwise it looks like the rebase was clean, its worth checking the compound* and dimension scripts, though.