### PR TITLE
Make sure mask arrays are int8 if doing inplace operations

### DIFF
--- a/scanpointgenerator/rois/linear_roi.py
+++ b/scanpointgenerator/rois/linear_roi.py
@@ -49,7 +49,9 @@ class LinearROI(ROI):
 
         # test for being past segment end-points
         dp = x * cphi + y * sphi
-        mask = (dp >= 0) & (dp <= self.length)
+        mask = np.full(len(x), True, dtype=np.int8)
+        mask &= dp >= 0
+        mask &= dp <= self.length
 
         # distance is scalar projection (dot-product) of
         # point difference to line normal (normal = (sphi, -cphi))

--- a/scanpointgenerator/rois/polygonal_roi.py
+++ b/scanpointgenerator/rois/polygonal_roi.py
@@ -42,7 +42,7 @@ class PolygonalROI(ROI):
         x = points[0]
         y = points[1]
         v1x, v1y = self.points_x[-1], self.points_y[-1]
-        mask = np.full(len(x), False, dtype=bool)
+        mask = np.full(len(x), False, dtype=np.int8)
         for v2x, v2y in zip(self.points_x, self.points_y):
             # skip horizontal edges
             if (v2y != v1y):

--- a/scanpointgenerator/rois/sector_roi.py
+++ b/scanpointgenerator/rois/sector_roi.py
@@ -63,7 +63,9 @@ class SectorROI(ROI):
         phi_s = phi_1 - phi_0
         phi_x -= phi_0 + 2*pi
         phi_x %= 2*pi
-        mask = (r2 <= self.radii[1]) & (r2 >= self.radii[0])
+        mask = np.full(len(x), 1, dtype=np.int8)
+        mask &= r2 <= self.radii[1]
+        mask &= r2 >= self.radii[0]
         mask &= (phi_x <= phi_s)
         return mask
 


### PR DESCRIPTION
This is to handle the case where the jython emulation for numpy does not
apply in-place bitwise operations on boolean arrays.