### PR TITLE
Store dimension nonzero indices as attribute in Dimension

### DIFF
--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -177,11 +177,9 @@ class CompoundGenerator(object):
         for dim in self.dimensions:
             self._dim_meta[dim] = {}
             dim.prepare()
-            indices = np.nonzero(dim.mask)[0]
-            if len(indices) == 0:
+            if dim.size == 0:
                 raise ValueError("Regions would exclude entire scan")
-            self.size *= len(indices)
-            self._dim_meta[dim]["indices"] = indices
+            self.size *= dim.size
 
         self.shape = tuple(dim.size for dim in self.dimensions)
         repeat = self.size
@@ -237,17 +235,16 @@ class CompoundGenerator(object):
         # many times we've run through them
         kc = 0 # the "cumulative" k for each dimension
         for dim in self.dimensions:
-            indices = self._dim_meta[dim]["indices"]
             i = int(n // self._dim_meta[dim]["repeat"])
-            i %= len(indices)
-            k = indices[i]
+            i %= dim.size
+            k = dim.indices[i]
             dim_reverse = False
             if dim.alternate and kc % 2 == 1:
-                i = len(indices) - i - 1
+                i = dim.size - i - 1
                 dim_reverse = True
-            kc *= len(indices)
+            kc *= dim.size
             kc += k
-            k = indices[i]
+            k = dim.indices[i]
             # need point k along each generator in dimension
             # in alternating case, need to sometimes go backward
             point.indexes.append(i)

--- a/scanpointgenerator/core/dimension.py
+++ b/scanpointgenerator/core/dimension.py
@@ -34,6 +34,7 @@ class Dimension(object):
         self._masks = []
         self._max_length = generator.size
         self._prepared = False
+        self.indices = []
 
     def get_positions(self, axis):
         """
@@ -64,7 +65,7 @@ class Dimension(object):
             points = np.append(p, points[:int(len(points)//2)])
         else:
             points = np.tile(points, int(tile))
-        return points[self.mask.nonzero()[0]]
+        return points[self.indices]
 
 
     def apply_excluder(self, excluder):
@@ -143,7 +144,8 @@ class Dimension(object):
         # we have to assume the "returned" mask may be edited in place
         # so we have to store a copy
         self.mask = mask
-        self.size = len(self.mask.nonzero()[0])
+        self.indices = self.mask.nonzero()[0]
+        self.size = len(self.indices)
         self._prepared = True
 
     @staticmethod


### PR DESCRIPTION
Prevents unnecessary recalculation of this attribute, wastes time for
large Dimensions.