### PR TITLE
Fix lower/upper bounds for grid special case.

### DIFF
--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -266,7 +266,8 @@ class CompoundGenerator(object):
                     j_lower, j_upper = j_upper, j_lower
                 for axis in g.axes:
                     point.positions[axis] = g.positions[axis][j]
-                    if g is self.generators[-1]:
+                    # apply "real" bounds to the "innermost" generator only
+                    if dim is self.dimensions[-1] and g is dim.generators[-1]:
                         point.lower[axis] = g.bounds[axis][j_lower]
                         point.upper[axis] = g.bounds[axis][j_upper]
                     else:

--- a/tests/test_core/test_compoundgenerator.py
+++ b/tests/test_core/test_compoundgenerator.py
@@ -609,6 +609,22 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
 
         self.assertEqual(positions, expected_positions)
 
+    def test_bounds_applied_in_rectangle_roi_secial_case(self):
+        x = LineGenerator("x", "mm", 0, 1, 2, True)
+        y = LineGenerator("y", "mm", 0, 1, 2, True)
+        r = RectangularROI([0, 0], 1, 1)
+        e = ROIExcluder([r], ["x", "y"])
+        g = CompoundGenerator([y, x], [e], [])
+        g.prepare()
+        p = g.get_point(0)
+        self.assertEqual({"x":-0.5, "y":0.}, p.lower)
+        self.assertEqual({"x":0., "y":0.}, p.positions)
+        self.assertEqual({"x":0.5, "y":0.}, p.upper)
+        p = g.get_point(2)
+        self.assertEqual({"x":1.5, "y":1}, p.lower)
+        self.assertEqual({"x":1, "y":1}, p.positions)
+        self.assertEqual({"x":0.5, "y":1}, p.upper)
+
 class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
     """Tests on datastructures internal to CompoundGenerator"""
 


### PR DESCRIPTION
The upper/lower bounds were not being applied to the innermost
line generator in the special case of a pair of line generators
inside an axis-aligned rectangle.

The comparison to detect which generator was the "inner-most" did
not account for the fact that the generators used in the Dimension
structures were not necessarily the same as the as the ones passed
to the CompoundGenerator.