### PR TITLE
Lift restrictions on excluders

### DIFF
--- a/docs/compoundgenerator.rst
+++ b/docs/compoundgenerator.rst
@@ -51,18 +51,6 @@ be run in reverse to give a snake scan.
 Restrictions
 ------------
 
-:ref:`excluders` must be defined on axes that are given by consecutive
-generators. Generators with axes filtered by an excluder must also have a
-common ``alternate`` setting. An exception is made for the outermost
-generator as it is not repeated.
-
-The following is `not` legal::
-
-    from scanpointgenerator import LineGenerator, CompoundGenerator, \
-    ROIExcluder, CircularROI
-
-    xs = LineGenerator("x", "mm", 0, 1, 2)
-    ys = LineGenerator("y", "mm", 0, 1, 2)
-    zs = LineGenerator("z", "mm", 0, 1, 2)
-    exc = ROIExcluder([CircularROI([0, 0], 1)], ["x", "z"])
-    gen = CompoundGenerator([zs, ys, xs], [exc], []) # xs and zs are not consecutive
+Generators with axes filtered by an excluder or between any such generators
+must have a common ``alternate`` setting. An exception is made for the
+outermost generator as it is not repeated.

--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -164,7 +164,7 @@ class CompoundGenerator(object):
             # merge "inner" into "outer"
             if dim_diff == -1:
                 # dim_1 is "outer" - preserves axis ordering
-                new_dim = Dimension.merge_dimensions(dim_1, dim_2)
+                new_dim = Dimension.merge_dimensions([dim_1, dim_2])
                 self.dimensions[self.dimensions.index(dim_1)] = new_dim
                 self.dimensions.remove(dim_2)
                 dim = new_dim

--- a/scanpointgenerator/core/excluder.py
+++ b/scanpointgenerator/core/excluder.py
@@ -27,7 +27,7 @@ class Excluder(object):
         """
         self.axes = axes
 
-    def create_mask(self, x_points, y_points):
+    def create_mask(self, *point_arrays):
         raise NotImplementedError("Method must be implemented in child class.")
 
     def to_dict(self):

--- a/scanpointgenerator/excluders/roiexcluder.py
+++ b/scanpointgenerator/excluders/roiexcluder.py
@@ -31,27 +31,28 @@ class ROIExcluder(Excluder):
 
         self.rois = rois
 
-    def create_mask(self, x_points, y_points):
+    def create_mask(self, *point_arrays):
         """Create a boolean array specifying the points to exclude.
 
         The resulting mask is created from the union of all ROIs.
 
         Args:
-            x_points(numpy.array(float)): Array of points for x-axis
-            y_points(numpy.array(float)): Array of points for y-axis
+            *point_arrays (numpy.array(float)): Array of points for each axis
 
         Returns:
             np.array(int8): Array of points to exclude
 
         """
-        if len(x_points) != len(y_points):
-            raise ValueError("Points lengths must be equal")
+        l = len(point_arrays[0])
+        for arr in point_arrays:
+            if len(arr) != l:
+                raise ValueError("Points lengths must be equal")
 
-        mask = np.zeros_like(x_points, dtype=np.int8)
+        mask = np.zeros_like(point_arrays[0], dtype=np.int8)
         for roi in self.rois:
             # Accumulate all True entries
             # Points outside of all ROIs will be excluded
-            mask |= roi.mask_points([x_points, y_points])
+            mask |= roi.mask_points(point_arrays)
 
         return mask
 

--- a/tests/test_excluders/test_roiexcluder.py
+++ b/tests/test_excluders/test_roiexcluder.py
@@ -1,16 +1,20 @@
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 import unittest
 
 from pkg_resources import require
 require("mock")
 from mock import MagicMock, patch, call
 
+from test_util import ScanPointGeneratorTest
 from scanpointgenerator import ROIExcluder
 from scanpointgenerator.compat import np
 
 roi_patch_path = "scanpointgenerator.core.ROI"
 
 
-class TestCreateMask(unittest.TestCase):
+class TestCreateMask(ScanPointGeneratorTest):
 
     def setUp(self):
         self.r1 = MagicMock()
@@ -72,3 +76,6 @@ class TestSerialisation(unittest.TestCase):
                                          call(self.r2_dict)])
         self.assertEqual(e.rois, [self.r1, self.r2])
         self.assertEqual(e.axes, ["x", "y"])
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Allows an excluder to act on axes that are provided by non-consecutive
generators and allows an excluder to act on more than two dimensions.

Whilst the latter feature isn't used right now (all regions passed to
ROIExcluder are two dimensional), the code to facilitate this isn't any more
complicated and the API change is backwards compatible.