### PR TITLE
Add initial implementation of NullPointGenerator

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Table of Contents
    spiralgenerator
    lissajousgenerator
    arraygenerator
+   staticpointgenerator
 
 .. toctree::
    :maxdepth: 1

--- a/docs/staticpointgenerator.rst
+++ b/docs/staticpointgenerator.rst
@@ -1,0 +1,30 @@
+Static Point Generator
+====================
+
+.. module:: scanpointgenerator
+
+.. autoclass:: StaticPointGenerator
+    :members:
+
+Examples
+--------
+
+Produce empty points to "multiply" existing generators within a :ref:`compoundgenerator`, adding an extra dimension.
+
+    >>> from scanpointgenerator import StaticPointGenerator, LineGenerator, CompoundGenerator
+    >>> line_gen = LineGenerator("x", "mm", 0.0, 1.0, 3)
+    >>> nullpoint_gen = StaticPointGenerator(2)
+    >>> gen = CompoundGenerator([nullpoint_gen, line_gen], [], [])
+    >>> gen.prepare()
+    >>> [point.positions for point in gen.iterator()]
+    [{'x': 0.0}, {'x': 0.5}, {'x': 1.0}, {'x': 0.0}, {'x': 0.5}, {'x': 1.0}]
+
+
+Using a StaticPointGenerator on its own in a compound generator is also allowed.
+
+    >>> from scanpointgenerator import StaticPointGenerator, CompoundGenerator
+    >>> nullpoint_gen = StaticPointGenerator(3)
+    >>> gen = CompoundGenerator([nullpoint_gen], [], [])
+    >>> gen.prepare()
+    >>> [point.positions for point in gen.iterator()]
+    [{}, {}, {}]

--- a/scanpointgenerator/core/compoundgenerator.py
+++ b/scanpointgenerator/core/compoundgenerator.py
@@ -23,7 +23,7 @@ from scanpointgenerator.core.excluder import Excluder
 from scanpointgenerator.excluders.roiexcluder import ROIExcluder
 from scanpointgenerator.core.mutator import Mutator
 from scanpointgenerator.rois import RectangularROI
-from scanpointgenerator.generators import LineGenerator
+from scanpointgenerator.generators import LineGenerator, StaticPointGenerator
 
 
 class CompoundGenerator(object):
@@ -152,6 +152,9 @@ class CompoundGenerator(object):
                 alternate = self.dimensions[d_end].alternate
                 # verify consistent alternate settings (ignoring outermost dimesion where it doesn't matter)
                 for d in self.dimensions[max(1, d_start):d_end]:
+                    # filter out dimensions consisting of a single StaticPointGenerator, since alternation means nothing
+                    if len(d.generators) == 1 and isinstance(d.generators[0], StaticPointGenerator):
+                        continue
                     if alternate != d.alternate:
                         raise ValueError("Nested generators connected by regions must have the same alternate setting")
                 merged_dim = Dimension.merge_dimensions(self.dimensions[d_start:d_end+1])

--- a/scanpointgenerator/generators/__init__.py
+++ b/scanpointgenerator/generators/__init__.py
@@ -17,3 +17,4 @@ from scanpointgenerator.generators.arraygenerator import ArrayGenerator
 from scanpointgenerator.generators.linegenerator import LineGenerator
 from scanpointgenerator.generators.lissajousgenerator import LissajousGenerator
 from scanpointgenerator.generators.spiralgenerator import SpiralGenerator
+from scanpointgenerator.generators.staticpointgenerator import StaticPointGenerator

--- a/scanpointgenerator/generators/staticpointgenerator.py
+++ b/scanpointgenerator/generators/staticpointgenerator.py
@@ -1,0 +1,38 @@
+###
+# Copyright (c) 2017 Diamond Light Source Ltd.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#    Charles Mita - initial API and implementation and/or initial documentation
+#
+###
+
+from scanpointgenerator.core import Generator
+
+@Generator.register_subclass("scanpointgenerator:generator/StaticPointGenerator:1.0")
+class StaticPointGenerator(Generator):
+    """Generate 'empty' points with no axis information"""
+
+    def __init__(self, size):
+        self.size = size
+        self.units = {}
+        self.axes = []
+
+    def to_dict(self):
+        d = {
+                "typeid" : self.typeid,
+                "size" : self.size,
+            }
+        return d
+
+    def prepare_arrays(self, index_array):
+        return {}
+
+    @classmethod
+    def from_dict(cls, d):
+        size = d["size"]
+        return cls(size)

--- a/tests/test_core/test_compoundgenerator.py
+++ b/tests/test_core/test_compoundgenerator.py
@@ -786,6 +786,34 @@ class CompoundGeneratorTest(ScanPointGeneratorTest):
         self.assertEqual({"y":"cm", "x":"mm"}, g.units)
         self.assertEqual(3, len(g.dimensions))
 
+    def test_staticpointgen_in_alternating(self):
+        x = LineGenerator("x", "mm", 0, 1, 3, True)
+        y = LineGenerator("y", "cm", 2, 3, 4, False)
+        m = StaticPointGenerator(5)
+        r = CircularROI((0.5, 2.5), 0.4)
+        e = ROIExcluder([r], ["x", "y"])
+        g = CompoundGenerator([y, m, x], [e], [])
+        g.prepare()
+
+        expected_positions = []
+        x_positions = [0.0, 0.5, 1.0]
+        direction = 1
+        for yp in [2.0, 2 + 1./3, 2 + 2./3, 3.0]:
+            for mp in range_(5):
+                for xp in x_positions[::direction]:
+                    if (xp-0.5)**2 + (yp-2.5)**2 <= 0.4**2:
+                        expected_positions.append({"y":yp, "x":xp})
+                direction *= -1
+
+        positions = [point.positions for point in g.iterator()]
+
+        self.assertEqual(expected_positions, positions)
+        self.assertEqual(len(expected_positions), g.size)
+        self.assertEqual((len(expected_positions),), g.shape)
+        self.assertEqual(["y", "x"], g.axes)
+        self.assertEqual({"y":"cm", "x":"mm"}, g.units)
+        self.assertEqual(1, len(g.dimensions))
+
 class CompoundGeneratorInternalDataTests(ScanPointGeneratorTest):
     """Tests on datastructures internal to CompoundGenerator"""
 

--- a/tests/test_generators/test_staticpointgenerator.py
+++ b/tests/test_generators/test_staticpointgenerator.py
@@ -1,0 +1,35 @@
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import unittest
+
+from test_util import ScanPointGeneratorTest
+from scanpointgenerator import StaticPointGenerator
+
+class StaticPointGeneratorTest(ScanPointGeneratorTest):
+
+    def test_init(self):
+        g = StaticPointGenerator(7)
+        self.assertEqual({}, g.units)
+        self.assertEqual([], g.axes)
+        self.assertEqual(7, g.size)
+
+    def test_to_dict(self):
+        g = StaticPointGenerator(7)
+        expected_dict = {
+                "typeid":"scanpointgenerator:generator/StaticPointGenerator:1.0",
+                "size": 7,
+                }
+
+        self.assertEqual(expected_dict, g.to_dict())
+
+    def test_from_dict(self):
+        d = {"size":6}
+        g = StaticPointGenerator.from_dict(d)
+        self.assertEqual(6, g.size)
+        self.assertEqual([], g.axes)
+        self.assertEqual({}, g.units)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The main function of this is to simply "multiply" existing generators
by adding an extra dimension. This adds no "axes" or new positions.

It can also be used on its own in a CompoundGenerator to provide empty
points.