### PR TITLE
ZipGenerator was not valid target for ConcatGenerator where units/axe…

### DIFF
--- a/scanpointgenerator/generators/concatgenerator.py
+++ b/scanpointgenerator/generators/concatgenerator.py
@@ -1,5 +1,5 @@
 from annotypes import Anno, deserialize_object, Array
-from scanpointgenerator.compat import np
+from scanpointgenerator.compat import np, _range
 from scanpointgenerator.core import Generator, AAlternate
 
 with Anno("The array containing points"):
@@ -23,10 +23,11 @@ class ConcatGenerator(Generator):
         axes = self.generators[0].axes
         size = sum(generator.size for generator in self.generators)
         for generator in self.generators:
-            assert generator.axes == axes, "You cannot Concat generators " \
+            for i in _range(len(axes)):
+                assert generator.axes[i] == axes[i], "You cannot Concat generators " \
                                                 "on different axes"
-            assert generator.units == units, "You cannot Concat " \
-                                             "generators with different units"
+                assert generator.units[i] == units[i], "You cannot Concat " \
+                                            "generators with different units"
             assert not generator.alternate, \
                 "Alternate should not be set on the component generators of a" \
                 "ConcatGenerator. Set it on the top level ConcatGenerator only."

--- a/scanpointgenerator/generators/concatgenerator.py
+++ b/scanpointgenerator/generators/concatgenerator.py
@@ -1,5 +1,5 @@
 from annotypes import Anno, deserialize_object, Array
-from scanpointgenerator.compat import np, _range
+from scanpointgenerator.compat import np, range_
 from scanpointgenerator.core import Generator, AAlternate
 
 with Anno("The array containing points"):
@@ -23,7 +23,7 @@ class ConcatGenerator(Generator):
         axes = self.generators[0].axes
         size = sum(generator.size for generator in self.generators)
         for generator in self.generators:
-            for i in _range(len(axes)):
+            for i in range_(len(axes)):
                 assert generator.axes[i] == axes[i], "You cannot Concat generators " \
                                                 "on different axes"
                 assert generator.units[i] == units[i], "You cannot Concat " \


### PR DESCRIPTION
I have a test that makes a ConcatGenerator from a ZipGenerator; putting together an ArrayGenerator (in x) a LineGenerator (in y) and a LissajousGenerator (in x,y), but I'm running into that the ConcatGenerator cannot concat on different axes, because the axes for the two generators look like this [Array([u'x', u'y']), Array([x, y])].
ZipGenerator.axes = a = Array([u'x', u'y'])
LissajousGenerator.axes = b = Array(['x', 'y'])

a != b
But
type(a) = annotypes._array.Array = type(b)
type(a[0]) = <type 'unicode'> = type(b[0])
a[0] = x = b[0]

And with this change, the ensuing ConcatGenerator, CompoundGenertor is valid and behaves as expected.
Generators should only be created when they are needed now, so a minor performance loss isn't the worst thing.