### PR TITLE
Fix for java.util.Arrays.ArrayList equality

### DIFF
--- a/scanpointgenerator/generators/concatgenerator.py
+++ b/scanpointgenerator/generators/concatgenerator.py
@@ -19,14 +19,14 @@ class ConcatGenerator(Generator):
 
         assert len(self.generators) > 0, "At least one generator needed"
 
-        units = self.generators[0].units
-        axes = self.generators[0].axes
+        units = list(self.generators[0].units)
+        axes = list(self.generators[0].axes)
         size = sum(generator.size for generator in self.generators)
         for generator in self.generators:
-            assert generator.axes == axes, "You cannot Concat generators " \
-                                                "on different axes"
-            assert generator.units == units, "You cannot Concat " \
-                                             "generators with different units"
+            assert list(generator.axes) == axes, "You cannot Concat generators" \
+                                                " on different axes (expected %s , received %s )" % (generator.axes.seq, axes)
+            assert list(generator.units) == units, "You cannot Concat  generators" \
+                                                " with different units (expected %s , received %s )" % (generator.units.seq, units)
             assert not generator.alternate, \
                 "Alternate should not be set on the component generators of a" \
                 "ConcatGenerator. Set it on the top level ConcatGenerator only."


### PR DESCRIPTION
private class ArrayList in java.util.Arrays equality method interfering with Annotypes wrapping equality method when called from Java/Jython. Fix for this as cannot guarantee never passing ArrayList of this time (n.b. the public ArrayList from java.util works fine)