### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -225,27 +225,27 @@ Added:
 
 - Initial structure with Line and Nested generators
 
-.. _Unreleased: https://github.com/dls-controls/scanpointgenerator/compare/3-1...HEAD
-.. _3-1: https://github.com/dls-controls/scanpointgenerator/compare/3-0..3-1
-.. _3-0: https://github.com/dls-controls/scanpointgenerator/compare/2-3..3-0
-.. _2-3: https://github.com/dls-controls/scanpointgenerator/compare/2-2-1...2-3
-.. _2-2-1: https://github.com/dls-controls/scanpointgenerator/compare/2-2...2-2-1
-.. _2-2: https://github.com/dls-controls/scanpointgenerator/compare/2-1-1...2-2
-.. _2-1-1: https://github.com/dls-controls/scanpointgenerator/compare/2-1-0...2-1-1
-.. _2-1-0: https://github.com/dls-controls/scanpointgenerator/compare/2-0-0...2-1-0
-.. _2-0-0: https://github.com/dls-controls/scanpointgenerator/compare/1-6-1...2-0-0
-.. _1-6-1: https://github.com/dls-controls/scanpointgenerator/compare/1-6...1-6-1
-.. _1-6: https://github.com/dls-controls/scanpointgenerator/compare/1-5...1-6
-.. _1-5: https://github.com/dls-controls/scanpointgenerator/compare/1-4...1-5
-.. _1-4: https://github.com/dls-controls/scanpointgenerator/compare/1-3-1...1-4
-.. _1-3-1: https://github.com/dls-controls/scanpointgenerator/compare/1-3...1-3-1
-.. _1-3: https://github.com/dls-controls/scanpointgenerator/compare/1-2-1...1-3
-.. _1-2-1: https://github.com/dls-controls/scanpointgenerator/compare/1-2...1-2
-.. _1-2: https://github.com/dls-controls/scanpointgenerator/compare/1-1...1-2
-.. _1-1: https://github.com/dls-controls/scanpointgenerator/compare/1-0...1-1
-.. _1-0: https://github.com/dls-controls/scanpointgenerator/compare/0-5...1-0
-.. _0-5: https://github.com/dls-controls/scanpointgenerator/compare/0-4...0-5
-.. _0-4: https://github.com/dls-controls/scanpointgenerator/compare/0-3...0-4
-.. _0-3: https://github.com/dls-controls/scanpointgenerator/compare/0-2...0-3
-.. _0-2: https://github.com/dls-controls/scanpointgenerator/compare/0-1...0-2
+.. _Unreleased: https://github.com/DiamondLightSource/scanpointgenerator/compare/3-1...HEAD
+.. _3-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/3-0..3-1
+.. _3-0: https://github.com/DiamondLightSource/scanpointgenerator/compare/2-3..3-0
+.. _2-3: https://github.com/DiamondLightSource/scanpointgenerator/compare/2-2-1...2-3
+.. _2-2-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/2-2...2-2-1
+.. _2-2: https://github.com/DiamondLightSource/scanpointgenerator/compare/2-1-1...2-2
+.. _2-1-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/2-1-0...2-1-1
+.. _2-1-0: https://github.com/DiamondLightSource/scanpointgenerator/compare/2-0-0...2-1-0
+.. _2-0-0: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-6-1...2-0-0
+.. _1-6-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-6...1-6-1
+.. _1-6: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-5...1-6
+.. _1-5: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-4...1-5
+.. _1-4: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-3-1...1-4
+.. _1-3-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-3...1-3-1
+.. _1-3: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-2-1...1-3
+.. _1-2-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-2...1-2
+.. _1-2: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-1...1-2
+.. _1-1: https://github.com/DiamondLightSource/scanpointgenerator/compare/1-0...1-1
+.. _1-0: https://github.com/DiamondLightSource/scanpointgenerator/compare/0-5...1-0
+.. _0-5: https://github.com/DiamondLightSource/scanpointgenerator/compare/0-4...0-5
+.. _0-4: https://github.com/DiamondLightSource/scanpointgenerator/compare/0-3...0-4
+.. _0-3: https://github.com/DiamondLightSource/scanpointgenerator/compare/0-2...0-3
+.. _0-2: https://github.com/DiamondLightSource/scanpointgenerator/compare/0-1...0-2
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ involves big changes, please file a ticket before making a pull request! We
 want to make sure you don't spend your time coding something that might not fit
 the scope of the project.
 
-.. _dls_controls repository: https://github.com/dls-controls/scanpointgenerator/issues
+.. _dls_controls repository: https://github.com/DiamondLightSource/scanpointgenerator/issues
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To install the latest release, type::
 
 To install the latest code directly from source, type::
 
-    pip install git+git://github.com/dls-controls/scanpointgenerator.git
+    pip install git+git://github.com/DiamondLightSource/scanpointgenerator.git
 
 Changelog
 ---------
@@ -36,12 +36,12 @@ Documentation
 
 Full documentation is available at http://scanpointgenerator.readthedocs.org
 
-.. |build-status| image:: https://travis-ci.org/dls-controls/scanpointgenerator.svg?style=flat
-    :target: https://travis-ci.org/dls-controls/scanpointgenerator
+.. |build-status| image:: https://travis-ci.org/DiamondLightSource/scanpointgenerator.svg?style=flat
+    :target: https://travis-ci.org/DiamondLightSource/scanpointgenerator
     :alt: Build Status
 
-.. |coverage| image:: https://coveralls.io/repos/dls-controls/scanpointgenerator/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/dls-controls/scanpointgenerator?branch=master
+.. |coverage| image:: https://coveralls.io/repos/DiamondLightSource/scanpointgenerator/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/DiamondLightSource/scanpointgenerator?branch=master
     :alt: Test coverage
 
 .. |pypi-version| image:: https://img.shields.io/pypi/v/scanpointgenerator.svg
@@ -52,12 +52,12 @@ Full documentation is available at http://scanpointgenerator.readthedocs.org
     :target: http://scanpointgenerator.readthedocs.org
     :alt: Documentation
 
-.. |health| image:: https://landscape.io/github/dls-controls/scanpointgenerator/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/dls-controls/scanpointgenerator/master
+.. |health| image:: https://landscape.io/github/DiamondLightSource/scanpointgenerator/master/landscape.svg?style=flat
+   :target: https://landscape.io/github/DiamondLightSource/scanpointgenerator/master
    :alt: Code Health
 
-.. _CHANGELOG: https://github.com/dls-controls/scanpointgenerator/blob/master/CHANGELOG.rst
-.. _CONTRIBUTING: https://github.com/dls-controls/scanpointgenerator/blob/master/CONTRIBUTING.rst
-.. _LICENSE: https://github.com/dls-controls/scanpointgenerator/blob/master/LICENSE
+.. _CHANGELOG: https://github.com/DiamondLightSource/scanpointgenerator/blob/master/CHANGELOG.rst
+.. _CONTRIBUTING: https://github.com/DiamondLightSource/scanpointgenerator/blob/master/CONTRIBUTING.rst
+.. _LICENSE: https://github.com/DiamondLightSource/scanpointgenerator/blob/master/LICENSE
 .. _GDA: http://www.opengda.org/
-.. _malcolm: https://github.com/dls-controls/malcolm
+.. _malcolm: https://github.com/DiamondLightSource/malcolm


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/scanpointgenerator` using https://gitlab.diamond.ac.uk/github/github-scripts